### PR TITLE
Fix missing Subscription ID for OSS Redis instances in PowerShell script

### DIFF
--- a/Pull-Azure-Cache-For-Redis-Stats.ps1
+++ b/Pull-Azure-Cache-For-Redis-Stats.ps1
@@ -157,7 +157,7 @@ foreach ($subscription in $subscriptions) {
     if ($subscriptionRedisInstances) {
         foreach ($ossInstance in $subscriptionRedisInstances) {
             if (-not $ossInstance.PSObject.Properties.Match("SubscriptionID")) {
-                $ossInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId -Force
+                $ossInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId
             }
             $redisInstances += $ossInstance
         }
@@ -167,7 +167,7 @@ foreach ($subscription in $subscriptions) {
     if ($PullAcre -and $subscriptionRedisEnterpriseInstances) {
         foreach ($enterpriseInstance in $subscriptionRedisEnterpriseInstances) {
             if (-not $enterpriseInstance.PSObject.Properties.Match("SubscriptionID")) {
-                $enterpriseInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId -Force
+                $enterpriseInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId
             }
             $redisInstances += $enterpriseInstance
         }
@@ -244,7 +244,13 @@ foreach ($instance in $redisInstances) {
             $subscriptionId = $instance.SubscriptionID
             if ([string]::IsNullOrEmpty($subscriptionId) -and $instance.Id) {
                 # Parse from resource ID: /subscriptions/{subscription-id}/resourceGroups/...
-                $subscriptionId = $instance.Id.Split('/')[2]
+                $idParts = $instance.Id.Split('/')
+                if ($idParts.Length -gt 2 -and $idParts[1] -eq 'subscriptions') {
+                    $subscriptionId = $idParts[2]
+                } else {
+                    Write-Warning "Unable to extract subscription ID from resource ID: $($instance.Id)"
+                    $subscriptionId = ""
+                }
             }
 
             $clusterRow = [ordered]@{ 

--- a/Pull-Azure-Cache-For-Redis-Stats.ps1
+++ b/Pull-Azure-Cache-For-Redis-Stats.ps1
@@ -153,23 +153,28 @@ foreach ($subscription in $subscriptions) {
         $subscriptionRedisEnterpriseInstances = Get-AzResource -ResourceType "Microsoft.Cache/redisEnterprise" -ExpandProperties
     }
 
-    # Check if SubscriptionID exists before adding it
-    $subscriptionRedisInstances | ForEach-Object {
-        if (-not $_.PSObject.Properties.Match("SubscriptionID")) {
-            $_ | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId | Out-Null
+    # Add SubscriptionID property to OSS instances and add to main array
+    if ($subscriptionRedisInstances) {
+        foreach ($ossInstance in $subscriptionRedisInstances) {
+            if (-not $ossInstance.PSObject.Properties.Match("SubscriptionID")) {
+                $ossInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId -Force
+            }
+            $redisInstances += $ossInstance
         }
     }
 
-    $subscriptionRedisEnterpriseInstances | ForEach-Object {
-        if (-not $_.PSObject.Properties.Match("SubscriptionID")) {
-            $_ | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId | Out-Null
+    # Add SubscriptionID property to Enterprise instances and add to main array
+    if ($PullAcre -and $subscriptionRedisEnterpriseInstances) {
+        foreach ($enterpriseInstance in $subscriptionRedisEnterpriseInstances) {
+            if (-not $enterpriseInstance.PSObject.Properties.Match("SubscriptionID")) {
+                $enterpriseInstance | Add-Member -MemberType NoteProperty -Name "SubscriptionID" -Value $subscription.SubscriptionId -Force
+            }
+            $redisInstances += $enterpriseInstance
         }
     }
 
-    if ($null -eq $subscriptionRedisInstances.Id -and $null -eq $subscriptionRedisEnterpriseInstances.Id) {
+    if (-not $subscriptionRedisInstances -and -not $subscriptionRedisEnterpriseInstances) {
         Write-Host "No Redis Instances found in subscription: $($subscription.Id)"
-    } else {
-        $redisInstances += ($subscriptionRedisInstances + $subscriptionRedisEnterpriseInstances)
     }
 }
 
@@ -235,8 +240,15 @@ foreach ($instance in $redisInstances) {
             $usedMemory = ((Get-Max-Metric $instance.Id "usedmemory$($_)") / 1024 / 1024).ToString("F2") # Convert bytes to megabytes
             $connectedClients = Get-Max-Metric $instance.Id "connectedclients$($_)"
 
+            # Extract subscription ID from resource ID if SubscriptionID property is not set
+            $subscriptionId = $instance.SubscriptionID
+            if ([string]::IsNullOrEmpty($subscriptionId) -and $instance.Id) {
+                # Parse from resource ID: /subscriptions/{subscription-id}/resourceGroups/...
+                $subscriptionId = $instance.Id.Split('/')[2]
+            }
+
             $clusterRow = [ordered]@{ 
-                "Subscription ID" = $instance.SubscriptionID; 
+                "Subscription ID" = $subscriptionId; 
                 "Resource Group" = $extendedInfo.ResourceGroupName;
                 "Region" = $instance.Location;
                 "DB Name" = $instance.Name;


### PR DESCRIPTION
## Summary
Fixes the issue where the Subscription ID column was empty for OSS (Basic, Standard, Premium) Redis instances in the PowerShell script output.

## Problem
The PowerShell script `Pull-Azure-Cache-For-Redis-Stats.ps1` was producing CSV output with missing Subscription IDs for OSS Redis instances, while Enterprise instances had their Subscription IDs populated correctly.

## Root Cause
1. **Array concatenation error**: Line 172 used `+` operator to concatenate PowerShell object arrays, which failed
2. **Missing property**: `Get-AzRedisCache` cmdlet does not return a `SubscriptionID` property for OSS instances
3. The Subscription ID exists in the resource `Id` property (e.g., `/subscriptions/{sub-id}/resourceGroups/...`) but wasn't being extracted

## Solution
1. **Fixed array concatenation**: Replaced failed `+` operation with proper foreach loops to add instances individually
2. **Added fallback extraction**: Parse subscription ID from resource ID for OSS instances: `$instance.Id.Split('/')[2]`
3. **Improved instance collection**: Better handling of both OSS and Enterprise instances with proper null checks

## Changes
- Refactored subscription instance collection (lines 156-177)
- Added subscription ID extraction from resource ID for OSS instances (lines 243-248)
- Improved error handling and null checks

## Testing
✅ Tested with real Azure environment containing:
- 1 OSS instance (Standard/C0)
- 5 Enterprise instances (E5, E10)

**Before fix:**
```csv
"Subscription ID","Resource Group","Region","DB Name",...
,"pl-learn","East US","acl-demo",...  ← Missing Subscription ID
"04a9ce47-...","nate-rg","East US","nategeo1",...  ← Has Subscription ID
```

**After fix:**
```csv
"Subscription ID","Resource Group","Region","DB Name",...
"04a9ce47-...","pl-learn","East US","acl-demo",...  ✅ Subscription ID present
"04a9ce47-...","nate-rg","East US","nategeo1",...  ✅ Subscription ID present
```

## Impact
- ✅ All Redis instance types (OSS and Enterprise) now have Subscription ID in CSV output
- ✅ No breaking changes to output format or columns
- ✅ Backward compatible with existing usage

## Related
This issue was reported by customers who found the Subscription ID missing for Basic, Standard, and Premium (OSS) Redis instances.